### PR TITLE
Gracefully close with hotkey when scratch has been modified

### DIFF
--- a/lib/scratch.js
+++ b/lib/scratch.js
@@ -87,12 +87,9 @@ export default {
 		let scratchEditor = this.getScratchEditor();
 		if (atom.config.get("scratch.autosave")) {
 			scratchEditor.save();
+			scratchEditor.destroy();
 		} else {
-			if (scratchEditor.shouldPromptToSave()) {
-				atom.workspace.getActivePane().promptToSaveItem(scratchEditor);
-			}
+			atom.workspace.getActivePane().destroyItem(scratchEditor, false);
 		}
-
-		scratchEditor.destroy()
 	}
 }


### PR DESCRIPTION
## Background

I reported this bug in https://github.com/destradax/scratch/issues/13. With autosave disabled, if a user modifies their scratch and uses the hotkey to close it, the `TextEditor` is destroyed before the user is prompted to save. When the user then clicks save in the prompt, they see an error:

![46265828-1e4e5000-c4df-11e8-811c-c29e5ddefc90](https://user-images.githubusercontent.com/7942714/46388918-e03e6100-c683-11e8-96a1-1b817da8ee08.png)

## The fix

This change uses the [`Pane` `destroyItem` function](https://atom.io/docs/api/v1.31.1/Pane#instance-destroyItem) to ensure that when a user without autosave enabled closes their scratch with the hotkey, it will remain open until they have chosen "Save," "Don't Save," or "Cancel."

This is the same behavior as when the user clicks the "X" on the tab to close their scratch. It does not impact the behavior for users with autosave enabled. I suspect that this change is less brittle to future API changes because the `destroyItem` function is publicly documented while `promptToSaveItem` is not.

## Before demo

![46265830-25755e00-c4df-11e8-9caf-b9a2a69ab735](https://user-images.githubusercontent.com/7942714/46389005-5c38a900-c684-11e8-8fed-ca14c3415a99.gif)

## After demo

![fix-demo](https://user-images.githubusercontent.com/7942714/46389057-bcc7e600-c684-11e8-8752-71317d1cc4dc.gif)

closes https://github.com/destradax/scratch/issues/13